### PR TITLE
Add gettext-base package to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -o /go/bin/dro
 
 FROM ubuntu:20.04 as executables
 
-RUN apt update && apt install wget curl unzip -y
+RUN apt update && apt install wget curl unzip gettext-base -y
 
 WORKDIR /execs
 RUN wget -q https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip -O terraform.zip && \


### PR DESCRIPTION
This allows using envsubst command in builds.